### PR TITLE
feat: add world scene support

### DIFF
--- a/src/logic/sceneFetcher.ts
+++ b/src/logic/sceneFetcher.ts
@@ -39,6 +39,36 @@ export async function createSceneFetcherComponent({
     return await processRemoteResponse(sceneData)
   }
 
+  async function getGameDataFromWorldScene(worldName: string, sceneCoords: string): Promise<string> {
+    const worldsContentServer = process.env.npm_config_worldsserver ?? catalystUrl
+    contentFetchBaseUrl = worldsContentServer + '/contents/'
+
+    const scenesUrl = `${worldsContentServer}/world/${worldName}/scenes`
+    console.log(`Fetching world scenes from: ${scenesUrl}`)
+    const fetchResponse = await fetch.fetch(scenesUrl)
+    const responseData = await fetchResponse.json()
+    const scenes: any[] = responseData.scenes ?? responseData
+
+    // Find the scene whose parcels contain the requested coordinates
+    const scene = scenes.find((s: any) => {
+      const parcels: string[] = s.parcels ?? s.entity?.metadata?.scene?.parcels ?? []
+      return parcels.includes(sceneCoords)
+    })
+
+    if (!scene) {
+      throw new Error(`ABORT: No scene found in world "${worldName}" at coordinates ${sceneCoords}. Available parcels: ${scenes.map((s: any) => (s.parcels ?? []).join(', ')).join(' | ')}`)
+    }
+
+    const sceneData = scene.entity
+    if (!sceneData) {
+      throw new Error(`ABORT: Scene found but entity data missing for world "${worldName}" at ${sceneCoords}`)
+    }
+
+    sceneId = sceneData.id
+    console.log(`Found world scene: ${sceneId} at ${sceneCoords}`)
+    return await processRemoteResponse(sceneData)
+  }
+
   async function processRemoteResponse(sceneData: any): Promise<string> {
     if (!process.env.npm_config_overwrite && existsSync(`${manifestFileDir}/${sceneId}${manifestFileNameEnd}`)) {
       console.log(`Manifest file already exists: ${sceneId}${manifestFileNameEnd}. Skipping...`)
@@ -89,6 +119,7 @@ export async function createSceneFetcherComponent({
   return {
     getGameDataFromRemoteSceneByCoords,
     getGameDataFromRemoteSceneByID,
-    getGameDataFromLocalScene
+    getGameDataFromLocalScene,
+    getGameDataFromWorldScene
   }
 }

--- a/src/logic/sceneLoader.ts
+++ b/src/logic/sceneLoader.ts
@@ -7,6 +7,10 @@ export async function loadOrReload({ sceneFetcher }: BaseComponents, loadingType
   if (loadingType === 'localScene') {
     sourceCode = await sceneFetcher.getGameDataFromLocalScene(targetScene)
     hash = 'localScene'
+  } else if (loadingType === 'worldScene') {
+    const [worldName, sceneCoords] = targetScene.split('|')
+    sourceCode = await sceneFetcher.getGameDataFromWorldScene(worldName, sceneCoords)
+    hash = 'worldScene'
   } else {
     if(doneBySceneID){
       sourceCode = await sceneFetcher.getGameDataFromRemoteSceneByID(targetScene)

--- a/src/service.ts
+++ b/src/service.ts
@@ -20,16 +20,23 @@ export async function main(program: Lifecycle.EntryPointParameters<BaseComponent
   if (localPath) {
     await loadOrReload(components, 'localScene', localPath, false)
   } else {
-    const sceneID = process.env.npm_config_sceneid
-    if (sceneID) {
-      await loadOrReload(components, 'remoteScene', sceneID, true)
-    }else{
+    const worldName = process.env.npm_config_world
+    if (worldName) {
       const remoteSceneCoords = process.env.npm_config_coords ?? await components.config.getString('REMOTE_SCENE_COORDS')
-      if (remoteSceneCoords) {
-        await loadOrReload(components, 'remoteScene', remoteSceneCoords, false)
+      if (!remoteSceneCoords) {
+        throw new Error('--coords is required when using --world')
+      }
+      await loadOrReload(components, 'worldScene', `${worldName}|${remoteSceneCoords}`, false)
+    } else {
+      const sceneID = process.env.npm_config_sceneid
+      if (sceneID) {
+        await loadOrReload(components, 'remoteScene', sceneID, true)
+      } else {
+        const remoteSceneCoords = process.env.npm_config_coords ?? await components.config.getString('REMOTE_SCENE_COORDS')
+        if (remoteSceneCoords) {
+          await loadOrReload(components, 'remoteScene', remoteSceneCoords, false)
+        }
       }
     }
-    
-
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,4 +12,5 @@ export type SceneFetcherComponent = {
   getGameDataFromRemoteSceneByCoords(sceneCoords: string): Promise<string>
   getGameDataFromRemoteSceneByID(paramSceneId: string): Promise<string>
   getGameDataFromLocalScene(scenePath: string): Promise<string>
+  getGameDataFromWorldScene(worldName: string, sceneCoords: string): Promise<string>
 }


### PR DESCRIPTION
## Summary
- Add `getGameDataFromWorldScene(worldName, sceneCoords)` to the scene fetcher — fetches scenes from `{worldsServer}/world/{worldName}/scenes`, finds the scene matching the given coordinates, and processes its entity through the existing pipeline
- Add `--world` and `--worldsserver` npm config options so the manifest builder can be invoked for world scenes
- Add `worldScene` loading type in the scene loader to route world requests through the new fetcher method
- The worlds content server uses `/contents/{hash}` (no `/content/` prefix), handled by setting `contentFetchBaseUrl` accordingly

### Usage
```bash
npm run start --catalyst=https://worlds-content-server.decentraland.org \
  --world=dclexperience.dcl.eth --coords=-9,-1 --overwrite --output=./output
```



🤖 Generated with [Claude Code](https://claude.com/claude-code)