### PR TITLE
fix: stubbed fetch returns ok: true so scenes don't throw on Response.ok

### DIFF
--- a/src/logic/scene-runtime/sdk7-runtime.ts
+++ b/src/logic/scene-runtime/sdk7-runtime.ts
@@ -66,10 +66,15 @@ export function createModuleRuntime(runtime: Record<string, any>): SDK7Module {
   })
 
   Object.defineProperty(runtime, 'fetch', {
+    // Stubbed to keep the manifest builder offline and deterministic.
+    // `ok: true` is required so scenes that gate on `response.ok` (e.g. Google
+    // Sheets feature-flag fetches) take their default/no-data branch and still
+    // spawn static content into the manifest instead of throwing.
     value: async (_url: string, _init: any) => {
       return {
+        ok: true,
         status: 200,
-        json: async () => {},
+        json: async () => ({}),
         text: async () => ''
       }
     }


### PR DESCRIPTION
## Summary
- Stubbed `fetch` in `sdk7-runtime.ts` was missing the `ok` field. Scenes that gate on `response.ok` (e.g. `if (!response.ok) throw ...`) threw on the first `await fetch(...)`, the throw was swallowed by the scene's own try/catch, and any subscriber callback waiting on the fetch never fired.
- Concrete impact found in Genesis Plaza's `central-plaza`: roads, imported objects (trees/benches/props), the store, and dynamic lights are all spawned inside the Google Sheets feature-flag callback. With the throw silently swallowed, none of them landed in the generated manifest.
- Returning `ok: true` lets such scenes take their default/no-data branch and still spawn static content into the manifest. Also tightens `json: async () => {}` (returns `undefined`) to `() => ({})` so any caller doing `(await res.json()).foo` doesn't crash.

## Test plan
- [ ] Re-run the manifest builder against `central-plaza` (Genesis City 0,0)
- [ ] Confirm `cp_roads.glb` and a sample of tree/bench GLTFs appear in `{sceneId}-lod-manifest.json`
- [ ] Spot-check a scene that *doesn't* use feature-flag-gated content to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)