### PR TITLE
docs: update Node version requirement in README to v24

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Original implementation commits history can be found in [the old prototype PR](h
 
 # IMPORTANT
 
-To be able to use the tool, `node` version `v18.14.2` is mandatory (newer or older versions may not work).
-https://nodejs.org/download/release/v18.14.2/
+To be able to use the tool, `node` version `v24` is required.
+https://nodejs.org/download/release/latest-v24.x/
 
 ## What this tool does
 


### PR DESCRIPTION
## Summary
- PR #13 already bumped CI to Node 24, but `README.md` still pointed at `v18.14.2` as the mandatory version.
- Updates the README to reflect the actual supported runtime so new contributors aren't misled.

## Test plan
- [ ] CI passes (this only touches docs)