### PR TITLE
fix: make Runtime.readFile work for SDK7 scenes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,8 @@ jobs:
       - run: npm ci
       - run: npm run build
 
-      # crashworld.dcl.eth hosts Genesis Plaza, deployed from:
-      # https://github.com/decentraland-scenes/Genesis-Plaza-2025/commit/30cdaffd752a02bc811dfdbd7e5aaaa4b97f595d
+      # crashworld.dcl.eth hosts Genesis Plaza (entity bafkreib3pp3kds7ftnvnaebbr2qzm2nnl4i4yuuc5b572ueuaeaj5rnnga,
+      # deployed 2026-07-02), from https://github.com/decentraland-scenes/Genesis-Plaza-2025
       - name: Generate crashworld manifest
         run: |
           mkdir -p e2e-output
@@ -57,12 +57,12 @@ jobs:
             exit 1
           fi
           echo "Generated: $GENERATED ($(stat -c%s "$GENERATED") bytes)"
-          # 958 is the GltfContainer count captured locally against the Genesis
-          # Plaza deploy linked above. After LWW dedup each (entityId, componentId)
+          # 782 is the GltfContainer count captured locally against the Genesis
+          # Plaza deploy referenced above. After LWW dedup each (entityId, componentId)
           # is unique, so this also equals the number of distinct 3D-model
           # placements baked into the scene. If Genesis Plaza is intentionally
           # redeployed, regenerate locally and update this constant.
-          EXPECTED=958
+          EXPECTED=782
           COUNT=$(jq '[.[] | select(.componentName == "core::GltfContainer")] | length' "$GENERATED")
           echo "GltfContainer count: $COUNT (expected: $EXPECTED)"
           if [ "$COUNT" -ne "$EXPECTED" ]; then

--- a/src/logic/scene-runtime/apis.ts
+++ b/src/logic/scene-runtime/apis.ts
@@ -1,5 +1,5 @@
 import { serializeCrdtMessages } from './logger'
-import { contentFetchBaseUrl, mainCrdt, sceneId, sdk6FetchComponent, sdk6SceneContent } from '../sceneFetcher'
+import { contentFetchBaseUrl, mainCrdt, sceneId, sceneFetchComponent, sceneContent } from '../sceneFetcher'
 import { writeFile, mkdir } from 'fs'
 import {CameraMode, engine, Entity, PutComponentOperation, Transform, UiCanvasInformation} from '@dcl/ecs/dist-cjs'
 import { ReadWriteByteBuffer } from '@dcl/ecs/dist-cjs/serialization/ByteBuffer'
@@ -200,10 +200,14 @@ export const LoadableApis: LoadableApis & { AdaptationLayerHelper: unknown } = {
     getRealm: async () => {
       return { realmInfo: undefined }
     },
-    // readFile is needed for the adaption-layer bridge to run SDK6 scenes as an SDK7 scene
+    // readFile serves the scene's own content files: the adaption-layer bridge uses it to run
+    // SDK6 scenes, and SDK7 scenes use it to load configs and composites at runtime.
     readFile: async ({ fileName }: { fileName: string }) => {
-      const fileHash = sdk6SceneContent.find(({ file }: any) => file === fileName).hash
-      const res = await sdk6FetchComponent.fetch(`${contentFetchBaseUrl}${fileHash}`)
+      const fileHash = sceneContent?.find(({ file }: any) => file === fileName)?.hash
+      if (!fileHash) {
+        throw new Error(`readFile: "${fileName}" not found in scene content`)
+      }
+      const res = await sceneFetchComponent.fetch(`${contentFetchBaseUrl}${fileHash}`)
       return {
         content: await res.arrayBuffer(),
         hash: fileHash

--- a/src/logic/sceneFetcher.ts
+++ b/src/logic/sceneFetcher.ts
@@ -4,8 +4,8 @@ import { BaseComponents, SceneFetcherComponent } from '../types'
 
 export let contentFetchBaseUrl: string | undefined = undefined
 const mainCRDTFileName = 'main.crdt'
-export let sdk6SceneContent: any
-export let sdk6FetchComponent: any
+export let sceneContent: any
+export let sceneFetchComponent: any
 export let mainCrdt: any
 export let sceneId: string = 'local-scene' // will get overwritten if a remote scene is targeted
 
@@ -77,12 +77,11 @@ export async function createSceneFetcherComponent({
 
     console.log(`Fetched scene data scene id:${sceneId}; sdk7? ${sceneData.metadata.runtimeVersion === '7'}`)
 
+    sceneContent = sceneData.content
+    sceneFetchComponent = fetch
+
     // SDK6 scenes support
     if (sceneData.metadata.runtimeVersion !== '7') {
-      // sdk6 scene content will be later read by the adaption-layer internally using the Runtime.readFile API
-      sdk6SceneContent = sceneData.content
-      sdk6FetchComponent = fetch
-
       const fetchResponse = await fetch.fetch(
         `https://renderer-artifacts.decentraland.org/sdk6-adaption-layer/main/index.js`
       )


### PR DESCRIPTION
## Problem

The sandbox's `Runtime.readFile` stub is backed by `sdk6SceneContent` / `sdk6FetchComponent`, which are only assigned when an SDK6 scene is detected (they were introduced solely for the sdk7-adaption-layer bridge). For SDK7 scenes they stay `undefined`, so every `readFile` call throws a `TypeError`.

SDK7 scenes do call `readFile` at runtime:
- newer tooling ships `assets/scene/main.composite` as a separate content file loaded through it, and
- code-driven scenes read their own config files with it.

When those reads fail, well-behaved scenes don't crash — they fall back to placeholder content. The builder then finishes normally and writes a **near-empty manifest**, so the failure is completely silent. For `swissverse.dcl.eth` (a code-driven 2025-parcel world) the manifest contained **3 components with a single phantom `models/building.glb`** (the scene's inlined dev fixture, a file that isn't even in its deployed content), which starves everything downstream of the manifest.

## Fix

- Assign the scene content mappings and fetch component for **every** remote scene, not just SDK6 ones.
- Rename `sdk6SceneContent` / `sdk6FetchComponent` → `sceneContent` / `sceneFetchComponent`: the sdk6 prefix encoded the stale assumption that only the adaption layer reads files, which is exactly what made this gap invisible when reading the code.
- Make `readFile` throw a descriptive error (`readFile: "<file>" not found in scene content`) instead of a bare `TypeError` when a file is missing.

## Verification

Ran the builder before/after against two worlds on `worlds-content-server.decentraland.org`:

| Scene | Before | After |
|---|---|---|
| `swissverse.dcl.eth` @ -55,106 (code-driven) | 3 components, 1 GltfContainer (dev fixture) | 5,492 components, 129 GltfContainers (22 unique srcs, all present in the deployed content) |
| `eax.dcl.eth` @ 0,4 (editor-made, state in `main.crdt`) | 13 components, 4 GltfContainers | identical — no regression |

SDK6 behavior is unchanged: the same values are assigned as before, in the same place relative to the adaption-layer fetch.

## CI baseline refresh (separate commit)

The crashworld e2e baseline was stale, not broken by this fix: `crashworld.dcl.eth` was redeployed on 2026-07-02 (after the last e2e run on `main`, June 7), and the current deploy bakes 782 distinct GltfContainer placements instead of 958. `main` and this branch both produce an identical 782-container manifest, deterministic across runs — so any push would have failed e2e; this PR was just the first one since the redeploy. The second commit updates the expected count per the workflow's own instruction and pins the deployed entity id in the comment.

Replaces #17 (closed: commit wasn't signed due to a misconfigured git client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
