### PR TITLE
fix: answer isServer=false so scenes spawn their client-side content

### DIFF
--- a/src/logic/scene-runtime/apis.ts
+++ b/src/logic/scene-runtime/apis.ts
@@ -157,7 +157,9 @@ export const LoadableApis: LoadableApis & { AdaptationLayerHelper: unknown } = {
       //console.log(outputJSONManifest)
       return { data: [] }
     },
-    isServer: async () => ({ isServer: true }),
+    // Answer as a client: scenes with a server/client split (e.g. Genesis Plaza) only spawn
+    // their visual content — the GltfContainers this manifest exists to capture — on clients.
+    isServer: async () => ({ isServer: false }),
     // Enum types that the compiler thinks we need for the EngineAPI.
     ECS6ComponentAttachToAvatar_AttachToAvatarAnchorPointId: {} as any,
     ECS6ComponentCameraModeArea_CameraMode: {} as any,


### PR DESCRIPTION
## Problem

The new Genesis Plaza deployment (`bafkreig4zx2kowhjlinc4s4fnvj3s3ak7dbzxe3zxfk5lcjjrf46wycmau`) fails LOD generation and gets quarantined. Its manifest ends up with only 3 GltfContainers (all `visible: false`, from `main.crdt`), so the Unity pipeline finds zero placements, downloads nothing, and crashes on the missing `_Downloaded` folder.

## Cause

The scene uses SDK7's server/client split and asks `EngineApi.isServer` on boot. The builder's stub has answered `isServer: true` since the initial commit, so the scene runs its server path and never spawns its visual content — that's the client's job, and the GltfContainers are exactly what the manifest exists to capture.

## Fix

Answer `isServer: false`. Verified against Genesis Plaza:

| `isServer` | manifest entries | GltfContainers |
|---|---|---|
| `true` (before) | 39 | 3 (all invisible) |
| `false` (after) | 2,861 | 675 (158 unique models) |

The `Unknown platform value: "lod-server-platform"` error the scene logs (from the `getExplorerInformation` stub) was also investigated and is harmless — flipping `isServer` alone produces the full manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)